### PR TITLE
Add -o option to pgtemp daemon for passing server configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+unreleased
+----------
+Add -o options to pgtemp daemon for postgresql server configs
+
+0.2
+---
+Documentation updates
+
 0.1.0
 -----
 Initial release

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 test:
 	cargo test --tests --examples --all-features
 
-# Run all tests with and without all features (excluding pg16 since github runners do not support it)
+# Run all tests with and without all features
 test-ci:
 	cargo test --tests --examples --no-default-features
 	cargo test --tests --examples --all-features
@@ -26,7 +26,8 @@ lint:
 		-A clippy::doc-markdown \
 		-A clippy::missing-panics-doc \
 		-A clippy::new-without-default \
-		-A clippy::expect-fun-call
+		-A clippy::expect-fun-call \
+		-A clippy::no_effect_underscore_binding # TODO: fixed in clippy, can remove eventually
 
 # Generate docs
 doc:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The pgtemp cli tool allows you to even more simply make temporary connections, a
 
 pgtemp supports loading (and dumping, in the library) the database to/from [dumpfiles via `pg_dump`](https://www.postgresql.org/docs/current/backup-dump.html).
 
+Note that the default postgres authentication configuration (`pg_hba.conf`) in most cases allows all local connections. Since pgtemp only allows you to make servers that listen on localhost, this means in most cases you do not need to provide a password to connect. You may set the server's `hba_file` parameter in `PgTempDBBuilder::with_config_param` or use the pgtemp daemon's `-o` flag to pass `hba_file` there.
+
 # Requirements
 You must install both the postgresql client and server packages. On Debian/Ubuntu, they are `postgresql postgresql-client`, on Fedora they are `postgresql postgresql-server`, and on Arch Linux they are `postgresql postgresql-libs`. Note also that Debian/Ubuntu install the standard postgres binaries into their own directory, so you must add them to your path. For an Ubuntu GitHub Actions runner, it looks like:
 

--- a/TODO
+++ b/TODO
@@ -5,7 +5,7 @@ await db.async_shutdown()
 
 - .pgpass file instead of just writing password to file? only seems to be an issue for createdb and really at that point we could just execute with psql instead.
 
-- support all builder options in cli (--persist, custom config params)
+- support all builder options in cli (e.g. --persist)
 
 - cache initial files from initdb or otherwise optimize all setup stuff
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,18 +446,12 @@ impl PgTempDBBuilder {
 
     /// Get user if set or return default
     pub fn get_user(&self) -> String {
-        self.db_user
-            .as_ref()
-            .cloned()
-            .unwrap_or(String::from("postgres"))
+        self.db_user.clone().unwrap_or(String::from("postgres"))
     }
 
     /// Get password if set or return default
     pub fn get_password(&self) -> String {
-        self.password
-            .as_ref()
-            .cloned()
-            .unwrap_or(String::from("password"))
+        self.password.clone().unwrap_or(String::from("password"))
     }
 
     /// Unlike the other getters, this getter will try to open a new socket to find an unused port,
@@ -471,10 +465,7 @@ impl PgTempDBBuilder {
 
     /// Get dbname if set or return default
     pub fn get_dbname(&self) -> String {
-        self.dbname
-            .as_ref()
-            .cloned()
-            .unwrap_or(String::from("postgres"))
+        self.dbname.clone().unwrap_or(String::from("postgres"))
     }
 }
 


### PR DESCRIPTION
Allows `PgTempDBBuilder::with_config_param` with pgtemp daemon