### PR TITLE
Don't crash on drop after `shutdown` call.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pgtemp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "axum",
  "clap",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,11 @@ impl PgTempDB {
         //     }
         // });
 
+        // If the server's process was already killed, stop.
+        if self.postgres_process.is_none() {
+            return;
+        }
+
         // do the dump while the postgres process is still running
         if let Some(path) = &self.dump_path {
             self.dump_database(path);

--- a/tests/basic_operations.rs
+++ b/tests/basic_operations.rs
@@ -130,3 +130,13 @@ async fn create_table_and_insert() {
     assert_eq!(id, 1);
     assert_eq!(name, "example name");
 }
+
+#[test]
+/// check that dropping the temp DB after calling shutdown doesn't trigger a panic
+fn safe_shutdown() {
+    let mut db = PgTempDB::new();
+    assert_eq!(db.db_name(), "postgres");
+
+    db.shutdown();
+    drop(db);
+}


### PR DESCRIPTION
`let mut postgres_process = self.postgres_process.take().unwrap();` panics the second time it is called.