### PR TITLE
Switch shutdown to use fast shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 unreleased
 ----------
+- Make shutdown use SIGINT for fast shutdown, which still actively terminates
+  connections but does not leak resources.
+  This is a breaking change - using the persist option does not use graceful
+  shutdown via SIGTERM anymore.
 
 0.4.0
 -----


### PR DESCRIPTION
- SIGKILL causes shared memory and segfaults to leak <https://www.postgresql.org/docs/current/server-shutdown.html>
- Just using SIGTERM everywhere creates deadlock conditions when used with connection poolers in some cases, but it would be nice to have a graceful shutdown option eventually.
- Ended up using SIGINT fast shutdown mode, which actively terminates connections rather than waiting for them to complete.
- This is technically a breaking change because using the persist option does not using graceful shutdown anymore.