### PR TITLE
add a bin_path option to the Builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ impl Drop for PgTempDB {
 // db config builder functions
 
 /// Builder struct for PgTempDB.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct PgTempDBBuilder {
     /// The directory in which to store the temporary PostgreSQL data directory.
     pub temp_dir_prefix: Option<PathBuf>,
@@ -286,22 +286,14 @@ pub struct PgTempDBBuilder {
     pub load_path: Option<PathBuf>,
     /// Other server configuration data to be set in `postgresql.conf` via `initdb -c`
     pub server_configs: HashMap<String, String>,
+    /// Prefix PostgreSQL binary names (`initdb`, `createdb`, and `postgres`) with this path, instead of searching $PATH
+    pub bin_path: Option<PathBuf>,
 }
 
 impl PgTempDBBuilder {
     /// Create a new [`PgTempDBBuilder`]
     pub fn new() -> PgTempDBBuilder {
-        PgTempDBBuilder {
-            temp_dir_prefix: None,
-            db_user: None,
-            password: None,
-            port: None,
-            dbname: None,
-            persist_data_dir: false,
-            dump_path: None,
-            load_path: None,
-            server_configs: HashMap::new(),
-        }
+        PgTempDBBuilder::default()
     }
 
     /// Parses the parameters out of a PostgreSQL connection URI and inserts them into the builder.
@@ -377,6 +369,13 @@ impl PgTempDBBuilder {
     #[must_use]
     pub fn with_config_param(mut self, key: &str, value: &str) -> Self {
         let _old = self.server_configs.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the directory that contains binaries like `initdb`, `createdb`, and `postgres`.
+    #[must_use]
+    pub fn with_bin_path(mut self, path: impl AsRef<Path>) -> Self {
+        self.bin_path = Some(PathBuf::from(path.as_ref()));
         self
     }
 

--- a/tests/startup.rs
+++ b/tests/startup.rs
@@ -60,3 +60,23 @@ fn test_tempdb_bringup_shutdown_persist() {
 
     assert!(conf_file.exists());
 }
+
+#[test]
+#[should_panic(expected = "this is not initdb")]
+/// Start a database by specifying the bin_path
+fn test_tempdb_bin_path() {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let bindir = tempfile::tempdir().unwrap();
+    for name in ["initdb", "createdb", "postgres"] {
+        let path = bindir.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(format!("#!/bin/sh\necho this is not {name}\nexit 1").as_bytes())
+            .unwrap();
+        let mut p = f.metadata().unwrap().permissions();
+        p.set_mode(0o700);
+        f.set_permissions(p).unwrap();
+    }
+    let _db = PgTempDB::builder().with_bin_path(&bindir).start();
+}


### PR DESCRIPTION
This parameter sets where initdb et al are searched for, instead of $PATH, which makes it possible for test harnesses to just specify the known location of the binaries, instead of making them be in $PATH, which is not conventional on, at least, Debian

I have some code which automatically searches for the highest 'N' /usr/lib/postgresql/N/bin, and then uses that. I could provide that code, but I think this approach is more general.