### PR TITLE
Change to fail on load errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl PgTempDB {
 
         let load_output = std::process::Command::new("psql")
             .arg(self.connection_uri())
-            .args(["--file", path_str])
+            .args(["--file", path_str, "--set", "ON_ERROR_STOP=1", "--single-transaction"])
             .output()
             .expect("failed to start psql. Is it installed and on your path?");
 


### PR DESCRIPTION
* Before any errors would silently be ignored.
* And the DB would be partially initialized.
* This created very hard to debug states.